### PR TITLE
Change error message assertion to strict equality

### DIFF
--- a/.tmp-stylelint/node_modules/fastq/test/promise.js
+++ b/.tmp-stylelint/node_modules/fastq/test/promise.js
@@ -193,14 +193,14 @@ test('push with worker throwing error', async function (t) {
   }, 1)
   q.error(function (err, task) {
     t.ok(err instanceof Error, 'global error handler should catch the error')
-    t.match(err.message, /test error/, 'error message should be "test error"')
+    t.equal(err.message, 'test error', 'error message should be "test error"')
     t.equal(task, 42, 'The task executed should be passed')
   })
   try {
     await q.push(42)
   } catch (err) {
     t.ok(err instanceof Error, 'push callback should catch the error')
-    t.match(err.message, /test error/, 'error message should be "test error"')
+    t.equal(err.message, 'test error', 'error message should be "test error"')
   }
 })
 
@@ -213,7 +213,7 @@ test('unshift with worker throwing error', async function (t) {
     await q.unshift(42)
   } catch (err) {
     t.ok(err instanceof Error, 'push callback should catch the error')
-    t.match(err.message, /test error/, 'error message should be "test error"')
+    t.equal(err.message, 'test error', 'error message should be "test error"')
   }
 })
 


### PR DESCRIPTION
fix: replace regex test with equality in fastq test to silence ReDoS false positive